### PR TITLE
Ignore *.swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ wp-cli.local.yml
 *.zip
 .idea
 .vscode/
+*.swp
 
 # Composer
 /vendor/


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Vim editor creates `.swp` files by default when editing files. These files are temporary and shouldn't be mistakenly added to git. This PR updates `.gitignore` so that git will ignore these files.

### How to test the changes in this Pull Request:

1. Run branch
2. Add a `foo.swp` file somewhere in your `navigation` directory tree
3. Run `git status` and verify that the `foo.swp` file isn't listed
