### PR TITLE
Fix dependencies

### DIFF
--- a/client/Navigation.js
+++ b/client/Navigation.js
@@ -32,7 +32,7 @@ export default class Navigation extends Component {
 
 	render() {
 		// @todo This should be updated to use a wp data store.
-		const items = window.wcSettings.wcNavigation || [];
+		const items = window.wcSettings && window.wcSettings.wcNavigation ? window.wcSettings.wcNavigation : [];
 
 		return (
 			<div className="woocommerce-navigation">

--- a/client/Navigation.js
+++ b/client/Navigation.js
@@ -4,7 +4,6 @@
 import { Component } from '@wordpress/element';
 
 export default class Navigation extends Component {
-
 	componentDidMount() {
 		// Collapse the original WP Menu.
 		const adminMenu = document.getElementById( 'adminmenumain' );
@@ -17,7 +16,7 @@ export default class Navigation extends Component {
 		return (
 			<li
 				key={ slug }
-				className={ `woocommerce-navigation__menu-item woocommerce-navigation__menu-item-depth-${depth}` }
+				className={ `woocommerce-navigation__menu-item woocommerce-navigation__menu-item-depth-${ depth }` }
 			>
 				<a href={ url }>{ title }</a>
 				{ item.children && item.children.length && (
@@ -28,13 +27,13 @@ export default class Navigation extends Component {
 					</ul>
 				) }
 			</li>
-		)
+		);
 	}
 
 	render() {
 		// @todo This should be updated to use a wp data store.
-		const items = window.wcNavigation || [];
-		
+		const items = window.wcSettings.wcNavigation || [];
+
 		return (
 			<div className="woocommerce-navigation">
 				<ul className="woocommerce-navigation__menu">

--- a/client/index.js
+++ b/client/index.js
@@ -9,6 +9,7 @@ import { render } from '@wordpress/element';
 import './stylesheets/index.scss';
 import Navigation from './navigation';
 
-const navigationRoot = document.getElementById( 'woocommerce-embedded-navigation' );
+const navigationRoot = document.getElementById(
+	'woocommerce-embedded-navigation'
+);
 render( <Navigation />, navigationRoot );
-

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -80,7 +80,7 @@ class Loader {
 		wp_register_script(
 			'woocommerce-navigation',
 			$script_url,
-			$script_asset['dependencies'],
+			array_merge( $script_asset['dependencies'], array( WC_ADMIN_APP ) ),
 			$script_asset['version'],
 			true
 		);


### PR DESCRIPTION
The sidebar wasn't loading correctly in both dependencies and data. This PR adds a dependency on wc-admin so that data can be acquired from `wcSettings`.

This fixes the issue, but I think its only a temporary fix (or we don't even need to merge) because there is a major delay associated with waiting for wc-admin to load first so we can use `\Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry`.

I'm open to merging this now so we can continue and address this later. Thoughts?