### PR TITLE
Migrate remaining WooCommerce menu items

### DIFF
--- a/client/stylesheets/index.scss
+++ b/client/stylesheets/index.scss
@@ -1,10 +1,11 @@
-@import "node_modules/@wordpress/base-styles/colors";
-@import "node_modules/@wordpress/base-styles/variables";
-@import "node_modules/@wordpress/base-styles/mixins";
-@import "node_modules/@wordpress/base-styles/breakpoints";
-@import "node_modules/@wordpress/base-styles/animations";
-@import "node_modules/@wordpress/base-styles/z-index";
+@import 'node_modules/@wordpress/base-styles/colors';
+@import 'node_modules/@wordpress/base-styles/variables';
+@import 'node_modules/@wordpress/base-styles/mixins';
+@import 'node_modules/@wordpress/base-styles/breakpoints';
+@import 'node_modules/@wordpress/base-styles/animations';
+@import 'node_modules/@wordpress/base-styles/z-index';
 @import '_variables.scss';
+@import '_mixins.scss';
 
 .woocommerce-navigation {
 	color: initial;

--- a/client/stylesheets/index.scss
+++ b/client/stylesheets/index.scss
@@ -26,3 +26,7 @@
 		display: none !important;
 	}
 }
+
+.toplevel_page_woocommerce ul.wp-submenu {
+	display: none;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1913,23 +1913,6 @@
 								"fastq": "^1.6.0"
 						}
 				},
-				"@npmcli/move-file": {
-						"version": "1.0.1",
-						"resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.0.1.tgz",
-						"integrity": "sha512-Uv6h1sT+0DrblvIrolFtbvM1FgWm+/sy4B3pvLp67Zys+thcukzS5ekn7HsZFGpWP4Q3fYJCljbWQE/XivMRLw==",
-						"dev": true,
-						"requires": {
-								"mkdirp": "^1.0.4"
-						},
-						"dependencies": {
-								"mkdirp": {
-										"version": "1.0.4",
-										"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-										"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-										"dev": true
-								}
-						}
-				},
 				"@sinonjs/commons": {
 						"version": "1.8.0",
 						"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
@@ -2142,9 +2125,9 @@
 						}
 				},
 				"@types/babel__traverse": {
-						"version": "7.0.13",
-						"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.13.tgz",
-						"integrity": "sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==",
+						"version": "7.0.12",
+						"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.12.tgz",
+						"integrity": "sha512-t4CoEokHTfcyfb4hUaF9oOHu9RmmNWnm1CP0YmMqOOfClKascOmvlEM736vlqeScuGvBDsHkf8R2INd4DWreQA==",
 						"dev": true,
 						"requires": {
 								"@babel/types": "^7.3.0"
@@ -2157,9 +2140,9 @@
 						"dev": true
 				},
 				"@types/glob": {
-						"version": "7.1.3",
-						"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-						"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+						"version": "7.1.2",
+						"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.2.tgz",
+						"integrity": "sha512-VgNIkxK+j7Nz5P7jvUZlRvhuPSmsEfS03b0alKcq5V/STUKAa3Plemsn5mrQUO7am6OErJ4rhGEGJbACclrtRA==",
 						"dev": true,
 						"requires": {
 								"@types/minimatch": "*",
@@ -2225,9 +2208,9 @@
 						"dev": true
 				},
 				"@types/node": {
-						"version": "14.0.20",
-						"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.20.tgz",
-						"integrity": "sha512-MRn/NP3dee8yL5QhbSA6riuwkS+UOcsPUMOIOG3KMUQpuor/2TopdRBu8QaaB4fGU+gz/bzyDWt0FtUbeJ8H1A==",
+						"version": "14.0.14",
+						"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
+						"integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==",
 						"dev": true
 				},
 				"@types/normalize-package-data": {
@@ -2273,9 +2256,9 @@
 						"dev": true
 				},
 				"@types/uglify-js": {
-						"version": "3.9.3",
-						"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
-						"integrity": "sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==",
+						"version": "3.9.2",
+						"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.2.tgz",
+						"integrity": "sha512-d6dIfpPbF+8B7WiCi2ELY7m0w1joD8cRW4ms88Emdb2w062NeEpbNCeWwVCgzLRpVG+5e74VFSg4rgJ2xXjEiQ==",
 						"dev": true,
 						"requires": {
 								"source-map": "^0.6.1"
@@ -2296,9 +2279,9 @@
 						"dev": true
 				},
 				"@types/webpack": {
-						"version": "4.41.21",
-						"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.21.tgz",
-						"integrity": "sha512-2j9WVnNrr/8PLAB5csW44xzQSJwS26aOnICsP3pSGCEdsu6KYtfQ6QJsVUKHWRnm1bL7HziJsfh5fHqth87yKA==",
+						"version": "4.41.18",
+						"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.18.tgz",
+						"integrity": "sha512-mQm2R8vV2BZE/qIDVYqmBVLfX73a8muwjs74SpjEyJWJxeXBbsI9L65Pcia9XfYLYWzD1c1V8m+L0p30y2N7MA==",
 						"dev": true,
 						"requires": {
 								"@types/anymatch": "*",
@@ -2605,9 +2588,9 @@
 						"dev": true
 				},
 				"@wordpress/babel-preset-default": {
-						"version": "4.17.0",
-						"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.17.0.tgz",
-						"integrity": "sha512-9SvyQIC2oYerc+zsZJtQH/P8KqKOJJJH+QrmCIrD2PQ1cw9QrF456sV/xHuNfaAoV3QGFLxP+0wVFOLKdU22DQ==",
+						"version": "4.16.0",
+						"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.16.0.tgz",
+						"integrity": "sha512-bJgT9al65flrXV7q1mjVYG8DOn7EYUSA1r60cHCK5tdyZ2uSHXS0+lsfpTfQNH1+pn/wair/8M6elbHV6Qor1Q==",
 						"dev": true,
 						"requires": {
 								"@babel/core": "^7.9.0",
@@ -2617,7 +2600,7 @@
 								"@babel/runtime": "^7.9.2",
 								"@wordpress/babel-plugin-import-jsx-pragma": "^2.7.0",
 								"@wordpress/browserslist-config": "^2.7.0",
-								"@wordpress/element": "^2.16.0",
+								"@wordpress/element": "^2.15.0",
 								"@wordpress/warning": "^1.2.0",
 								"core-js": "^3.6.4"
 						}
@@ -2646,9 +2629,9 @@
 						}
 				},
 				"@wordpress/element": {
-						"version": "2.16.0",
-						"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.16.0.tgz",
-						"integrity": "sha512-1ijo/GR/uBfL4teCQ3oFdUTqkeV2EZ32SCvXl30iPbqYmaNSzT1ZI1dlW8GO5o5UBja9BG11hnaOwm93pE2y2A==",
+						"version": "2.15.0",
+						"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.15.0.tgz",
+						"integrity": "sha512-XXJxvjlQo0+1L+QFUXSWc8HCPR3I9aG0yxs+kJ8k8SHQxkUOZkqLQLYtwoNJpAlvgyKeFQNigpoddjoVbDDm7Q==",
 						"dev": true,
 						"requires": {
 								"@babel/runtime": "^7.9.2",
@@ -2719,23 +2702,15 @@
 						"dev": true
 				},
 				"@wordpress/postcss-plugins-preset": {
-						"version": "1.3.0",
-						"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-1.3.0.tgz",
-						"integrity": "sha512-i4SEAsPN8NMxCUpECj41Yb0pmW5PjypwfNdtzzqke6YQisGlCcKO2AF6F+1HTDNXc7SbBJFP6UbvrY4db5hK4g==",
+						"version": "1.2.0",
+						"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-1.2.0.tgz",
+						"integrity": "sha512-7vnjByaTzGh6HTVL9Wy/GpJPhyWRPxY03zGBezyO4vzrSdfZ0u3Pwydx6/516ezD15qeuFo7VX2ny0rs1QklzA==",
 						"dev": true,
 						"requires": {
-								"@wordpress/base-styles": "^2.0.0",
+								"@wordpress/base-styles": "^1.11.0",
 								"@wordpress/postcss-themes": "^2.6.0",
 								"autoprefixer": "^9.4.5",
 								"postcss-custom-properties": "^9.1.1"
-						},
-						"dependencies": {
-								"@wordpress/base-styles": {
-										"version": "2.0.0",
-										"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-2.0.0.tgz",
-										"integrity": "sha512-l0/j0+nVBvCtd/PFj/g6J2R8XuVLLRCNV2jSlnf0SPuswBZ2NYPvCLmf/OZ1Nw/c2O+Erdvq8IdYvXOObewqxQ==",
-										"dev": true
-								}
 						}
 				},
 				"@wordpress/postcss-themes": {
@@ -2754,18 +2729,18 @@
 						"dev": true
 				},
 				"@wordpress/scripts": {
-						"version": "12.1.0",
-						"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-12.1.0.tgz",
-						"integrity": "sha512-/++aorfRCUOrWi5Skgsu4O+Xwe6YGP03iQhaMsz53TGQwmxbFbYkYE+B3T+36eoIPSSmubH6BcCOU7HusUXlhQ==",
+						"version": "12.0.0",
+						"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-12.0.0.tgz",
+						"integrity": "sha512-nYRPbt9Ii6GZC1irmMRxYENiZ47lUqdl5d5UyUb75MDTmAWdN3e+56lVHFGiGhqflw1AyiU+l1DTJWkGXSPs7w==",
 						"dev": true,
 						"requires": {
 								"@svgr/webpack": "^5.2.0",
-								"@wordpress/babel-preset-default": "^4.17.0",
+								"@wordpress/babel-preset-default": "^4.16.0",
 								"@wordpress/dependency-extraction-webpack-plugin": "^2.8.0",
 								"@wordpress/eslint-plugin": "^7.1.0",
 								"@wordpress/jest-preset-default": "^6.2.0",
 								"@wordpress/npm-package-json-lint-config": "^3.1.0",
-								"@wordpress/postcss-plugins-preset": "^1.3.0",
+								"@wordpress/postcss-plugins-preset": "^1.2.0",
 								"@wordpress/prettier-config": "^0.3.0",
 								"babel-jest": "^25.3.0",
 								"babel-loader": "^8.1.0",
@@ -2795,7 +2770,6 @@
 								"source-map-loader": "^0.2.4",
 								"stylelint": "^13.6.0",
 								"stylelint-config-wordpress": "^17.0.0",
-								"terser-webpack-plugin": "^3.0.3",
 								"thread-loader": "^2.1.3",
 								"url-loader": "^3.0.0",
 								"webpack": "^4.42.0",
@@ -2814,31 +2788,6 @@
 												"color-convert": "^2.0.1"
 										}
 								},
-								"cacache": {
-										"version": "15.0.4",
-										"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.4.tgz",
-										"integrity": "sha512-YlnKQqTbD/6iyoJvEY3KJftjrdBYroCbxxYXzhOzsFLWlp6KX4BOlEf4mTx0cMUfVaTS3ENL2QtDWeRYoGLkkw==",
-										"dev": true,
-										"requires": {
-												"@npmcli/move-file": "^1.0.1",
-												"chownr": "^2.0.0",
-												"fs-minipass": "^2.0.0",
-												"glob": "^7.1.4",
-												"infer-owner": "^1.0.4",
-												"lru-cache": "^5.1.1",
-												"minipass": "^3.1.1",
-												"minipass-collect": "^1.0.2",
-												"minipass-flush": "^1.0.5",
-												"minipass-pipeline": "^1.2.2",
-												"mkdirp": "^1.0.3",
-												"p-map": "^4.0.0",
-												"promise-inflight": "^1.0.1",
-												"rimraf": "^3.0.2",
-												"ssri": "^8.0.0",
-												"tar": "^6.0.2",
-												"unique-filename": "^1.1.1"
-										}
-								},
 								"chalk": {
 										"version": "4.1.0",
 										"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -2848,12 +2797,6 @@
 												"ansi-styles": "^4.1.0",
 												"supports-color": "^7.1.0"
 										}
-								},
-								"chownr": {
-										"version": "2.0.0",
-										"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-										"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-										"dev": true
 								},
 								"color-convert": {
 										"version": "2.0.1",
@@ -2870,169 +2813,11 @@
 										"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 										"dev": true
 								},
-								"find-cache-dir": {
-										"version": "3.3.1",
-										"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-										"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
-										"dev": true,
-										"requires": {
-												"commondir": "^1.0.1",
-												"make-dir": "^3.0.2",
-												"pkg-dir": "^4.1.0"
-										}
-								},
-								"find-up": {
-										"version": "4.1.0",
-										"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-										"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-										"dev": true,
-										"requires": {
-												"locate-path": "^5.0.0",
-												"path-exists": "^4.0.0"
-										}
-								},
 								"has-flag": {
 										"version": "4.0.0",
 										"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 										"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 										"dev": true
-								},
-								"jest-worker": {
-										"version": "26.1.0",
-										"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.1.0.tgz",
-										"integrity": "sha512-Z9P5pZ6UC+kakMbNJn+tA2RdVdNX5WH1x+5UCBZ9MxIK24pjYtFt96fK+UwBTrjLYm232g1xz0L3eTh51OW+yQ==",
-										"dev": true,
-										"requires": {
-												"merge-stream": "^2.0.0",
-												"supports-color": "^7.0.0"
-										}
-								},
-								"locate-path": {
-										"version": "5.0.0",
-										"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-										"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-										"dev": true,
-										"requires": {
-												"p-locate": "^4.1.0"
-										}
-								},
-								"make-dir": {
-										"version": "3.1.0",
-										"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-										"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-										"dev": true,
-										"requires": {
-												"semver": "^6.0.0"
-										}
-								},
-								"mkdirp": {
-										"version": "1.0.4",
-										"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-										"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-										"dev": true
-								},
-								"p-limit": {
-										"version": "3.0.1",
-										"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.1.tgz",
-										"integrity": "sha512-mw/p92EyOzl2MhauKodw54Rx5ZK4624rNfgNaBguFZkHzyUG9WsDzFF5/yQVEJinbJDdP4jEfMN+uBquiGnaLg==",
-										"dev": true,
-										"requires": {
-												"p-try": "^2.0.0"
-										}
-								},
-								"p-locate": {
-										"version": "4.1.0",
-										"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-										"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-										"dev": true,
-										"requires": {
-												"p-limit": "^2.2.0"
-										},
-										"dependencies": {
-												"p-limit": {
-														"version": "2.3.0",
-														"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-														"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-														"dev": true,
-														"requires": {
-																"p-try": "^2.0.0"
-														}
-												}
-										}
-								},
-								"p-map": {
-										"version": "4.0.0",
-										"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-										"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-										"dev": true,
-										"requires": {
-												"aggregate-error": "^3.0.0"
-										}
-								},
-								"path-exists": {
-										"version": "4.0.0",
-										"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-										"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-										"dev": true
-								},
-								"pkg-dir": {
-										"version": "4.2.0",
-										"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-										"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-										"dev": true,
-										"requires": {
-												"find-up": "^4.0.0"
-										}
-								},
-								"rimraf": {
-										"version": "3.0.2",
-										"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-										"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-										"dev": true,
-										"requires": {
-												"glob": "^7.1.3"
-										}
-								},
-								"schema-utils": {
-										"version": "2.7.0",
-										"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-										"integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-										"dev": true,
-										"requires": {
-												"@types/json-schema": "^7.0.4",
-												"ajv": "^6.12.2",
-												"ajv-keywords": "^3.4.1"
-										}
-								},
-								"semver": {
-										"version": "6.3.0",
-										"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-										"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-										"dev": true
-								},
-								"serialize-javascript": {
-										"version": "4.0.0",
-										"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-										"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-										"dev": true,
-										"requires": {
-												"randombytes": "^2.1.0"
-										}
-								},
-								"source-map": {
-										"version": "0.6.1",
-										"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-										"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-										"dev": true
-								},
-								"ssri": {
-										"version": "8.0.0",
-										"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
-										"integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
-										"dev": true,
-										"requires": {
-												"minipass": "^3.1.1"
-										}
 								},
 								"supports-color": {
 										"version": "7.1.0",
@@ -3042,43 +2827,6 @@
 										"requires": {
 												"has-flag": "^4.0.0"
 										}
-								},
-								"tar": {
-										"version": "6.0.2",
-										"resolved": "https://registry.npmjs.org/tar/-/tar-6.0.2.tgz",
-										"integrity": "sha512-Glo3jkRtPcvpDlAs/0+hozav78yoXKFr+c4wgw62NNMO3oo4AaJdCo21Uu7lcwr55h39W2XD1LMERc64wtbItg==",
-										"dev": true,
-										"requires": {
-												"chownr": "^2.0.0",
-												"fs-minipass": "^2.0.0",
-												"minipass": "^3.0.0",
-												"minizlib": "^2.1.0",
-												"mkdirp": "^1.0.3",
-												"yallist": "^4.0.0"
-										}
-								},
-								"terser-webpack-plugin": {
-										"version": "3.0.6",
-										"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-3.0.6.tgz",
-										"integrity": "sha512-z3HLOOPUHkCNGkeEHqqiMAIy1pjpHwS1o+i6Zn0Ws3EAvHJj46737efNNEvJ0Vx9BdDQM83d56qySDJOSORA0A==",
-										"dev": true,
-										"requires": {
-												"cacache": "^15.0.4",
-												"find-cache-dir": "^3.3.1",
-												"jest-worker": "^26.0.0",
-												"p-limit": "^3.0.1",
-												"schema-utils": "^2.6.6",
-												"serialize-javascript": "^4.0.0",
-												"source-map": "^0.6.1",
-												"terser": "^4.8.0",
-												"webpack-sources": "^1.4.3"
-										}
-								},
-								"yallist": {
-										"version": "4.0.0",
-										"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-										"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-										"dev": true
 								}
 						}
 				},
@@ -3155,24 +2903,6 @@
 						"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
 						"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
 						"dev": true
-				},
-				"aggregate-error": {
-						"version": "3.0.1",
-						"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-						"integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
-						"dev": true,
-						"requires": {
-								"clean-stack": "^2.0.0",
-								"indent-string": "^4.0.0"
-						},
-						"dependencies": {
-								"indent-string": {
-										"version": "4.0.0",
-										"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-										"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-										"dev": true
-								}
-						}
 				},
 				"airbnb-prop-types": {
 						"version": "2.16.0",
@@ -4562,12 +4292,6 @@
 								}
 						}
 				},
-				"clean-stack": {
-						"version": "2.2.0",
-						"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-						"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-						"dev": true
-				},
 				"clean-webpack-plugin": {
 						"version": "3.0.0",
 						"resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
@@ -4576,107 +4300,6 @@
 						"requires": {
 								"@types/webpack": "^4.4.31",
 								"del": "^4.1.1"
-						}
-				},
-				"cli-cursor": {
-						"version": "3.1.0",
-						"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-						"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-						"dev": true,
-						"requires": {
-								"restore-cursor": "^3.1.0"
-						}
-				},
-				"cli-truncate": {
-						"version": "2.1.0",
-						"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-						"integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-						"dev": true,
-						"requires": {
-								"slice-ansi": "^3.0.0",
-								"string-width": "^4.2.0"
-						},
-						"dependencies": {
-								"ansi-regex": {
-										"version": "5.0.0",
-										"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-										"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-										"dev": true
-								},
-								"ansi-styles": {
-										"version": "4.2.1",
-										"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-										"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-										"dev": true,
-										"requires": {
-												"@types/color-name": "^1.1.1",
-												"color-convert": "^2.0.1"
-										}
-								},
-								"astral-regex": {
-										"version": "2.0.0",
-										"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-										"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-										"dev": true
-								},
-								"color-convert": {
-										"version": "2.0.1",
-										"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-										"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-										"dev": true,
-										"requires": {
-												"color-name": "~1.1.4"
-										}
-								},
-								"color-name": {
-										"version": "1.1.4",
-										"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-										"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-										"dev": true
-								},
-								"emoji-regex": {
-										"version": "8.0.0",
-										"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-										"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-										"dev": true
-								},
-								"is-fullwidth-code-point": {
-										"version": "3.0.0",
-										"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-										"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-										"dev": true
-								},
-								"slice-ansi": {
-										"version": "3.0.0",
-										"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-										"integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-										"dev": true,
-										"requires": {
-												"ansi-styles": "^4.0.0",
-												"astral-regex": "^2.0.0",
-												"is-fullwidth-code-point": "^3.0.0"
-										}
-								},
-								"string-width": {
-										"version": "4.2.0",
-										"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-										"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-										"dev": true,
-										"requires": {
-												"emoji-regex": "^8.0.0",
-												"is-fullwidth-code-point": "^3.0.0",
-												"strip-ansi": "^6.0.0"
-										}
-								},
-								"strip-ansi": {
-										"version": "6.0.0",
-										"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-										"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-										"dev": true,
-										"requires": {
-												"ansi-regex": "^5.0.0"
-										}
-								}
 						}
 				},
 				"cliui": {
@@ -4854,12 +4477,6 @@
 						"version": "1.0.1",
 						"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 						"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-						"dev": true
-				},
-				"compare-versions": {
-						"version": "3.6.0",
-						"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
-						"integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
 						"dev": true
 				},
 				"component-emitter": {
@@ -5358,12 +4975,6 @@
 						"version": "0.2.0",
 						"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 						"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-						"dev": true
-				},
-				"dedent": {
-						"version": "0.7.0",
-						"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-						"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
 						"dev": true
 				},
 				"deep-extend": {
@@ -6824,15 +6435,6 @@
 						"integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
 						"dev": true
 				},
-				"figures": {
-						"version": "3.2.0",
-						"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-						"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-						"dev": true,
-						"requires": {
-								"escape-string-regexp": "^1.0.5"
-						}
-				},
 				"file-entry-cache": {
 						"version": "5.0.1",
 						"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
@@ -6947,15 +6549,6 @@
 						"dev": true,
 						"requires": {
 								"locate-path": "^3.0.0"
-						}
-				},
-				"find-versions": {
-						"version": "3.2.0",
-						"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
-						"integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
-						"dev": true,
-						"requires": {
-								"semver-regex": "^2.0.0"
 						}
 				},
 				"findup-sync": {
@@ -7137,15 +6730,6 @@
 						"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
 						"dev": true
 				},
-				"fs-minipass": {
-						"version": "2.1.0",
-						"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-						"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-						"dev": true,
-						"requires": {
-								"minipass": "^3.0.0"
-						}
-				},
 				"fs-write-stream-atomic": {
 						"version": "1.0.10",
 						"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -7284,12 +6868,6 @@
 						"version": "2.0.5",
 						"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 						"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-						"dev": true
-				},
-				"get-own-enumerable-property-symbols": {
-						"version": "3.0.2",
-						"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
-						"integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
 						"dev": true
 				},
 				"get-package-type": {
@@ -7793,119 +7371,6 @@
 						"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
 						"dev": true
 				},
-				"husky": {
-						"version": "4.2.5",
-						"resolved": "https://registry.npmjs.org/husky/-/husky-4.2.5.tgz",
-						"integrity": "sha512-SYZ95AjKcX7goYVZtVZF2i6XiZcHknw50iXvY7b0MiGoj5RwdgRQNEHdb+gPDPCXKlzwrybjFjkL6FOj8uRhZQ==",
-						"dev": true,
-						"requires": {
-								"chalk": "^4.0.0",
-								"ci-info": "^2.0.0",
-								"compare-versions": "^3.6.0",
-								"cosmiconfig": "^6.0.0",
-								"find-versions": "^3.2.0",
-								"opencollective-postinstall": "^2.0.2",
-								"pkg-dir": "^4.2.0",
-								"please-upgrade-node": "^3.2.0",
-								"slash": "^3.0.0",
-								"which-pm-runs": "^1.0.0"
-						},
-						"dependencies": {
-								"ansi-styles": {
-										"version": "4.2.1",
-										"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-										"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-										"dev": true,
-										"requires": {
-												"@types/color-name": "^1.1.1",
-												"color-convert": "^2.0.1"
-										}
-								},
-								"chalk": {
-										"version": "4.1.0",
-										"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-										"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-										"dev": true,
-										"requires": {
-												"ansi-styles": "^4.1.0",
-												"supports-color": "^7.1.0"
-										}
-								},
-								"color-convert": {
-										"version": "2.0.1",
-										"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-										"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-										"dev": true,
-										"requires": {
-												"color-name": "~1.1.4"
-										}
-								},
-								"color-name": {
-										"version": "1.1.4",
-										"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-										"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-										"dev": true
-								},
-								"find-up": {
-										"version": "4.1.0",
-										"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-										"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-										"dev": true,
-										"requires": {
-												"locate-path": "^5.0.0",
-												"path-exists": "^4.0.0"
-										}
-								},
-								"has-flag": {
-										"version": "4.0.0",
-										"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-										"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-										"dev": true
-								},
-								"locate-path": {
-										"version": "5.0.0",
-										"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-										"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-										"dev": true,
-										"requires": {
-												"p-locate": "^4.1.0"
-										}
-								},
-								"p-locate": {
-										"version": "4.1.0",
-										"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-										"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-										"dev": true,
-										"requires": {
-												"p-limit": "^2.2.0"
-										}
-								},
-								"path-exists": {
-										"version": "4.0.0",
-										"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-										"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-										"dev": true
-								},
-								"pkg-dir": {
-										"version": "4.2.0",
-										"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-										"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-										"dev": true,
-										"requires": {
-												"find-up": "^4.0.0"
-										}
-								},
-								"supports-color": {
-										"version": "7.1.0",
-										"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-										"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-										"dev": true,
-										"requires": {
-												"has-flag": "^4.0.0"
-										}
-								}
-						}
-				},
 				"iconv-lite": {
 						"version": "0.4.24",
 						"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -8362,12 +7827,6 @@
 						"version": "1.0.4",
 						"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
 						"integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
-						"dev": true
-				},
-				"is-obj": {
-						"version": "1.0.1",
-						"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-						"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 						"dev": true
 				},
 				"is-path-cwd": {
@@ -10238,9 +9697,9 @@
 						}
 				},
 				"js-base64": {
-						"version": "2.6.3",
-						"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.3.tgz",
-						"integrity": "sha512-fiUvdfCaAXoQTHdKMgTvg6IkecXDcVz6V5rlftUTclF9IKBjMizvSdQaCl/z/6TApDeby5NL+axYou3i0mu1Pg==",
+						"version": "2.6.2",
+						"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.2.tgz",
+						"integrity": "sha512-1hgLrLIrmCgZG+ID3VoLNLOSwjGnoZa8tyrUdEteMeIzsT6PH7PMLyUvbDwzNE56P3PNxyvuIOx4Uh2E5rzQIw==",
 						"dev": true
 				},
 				"js-tokens": {
@@ -10477,301 +9936,6 @@
 								"uc.micro": "^1.0.1"
 						}
 				},
-				"lint-staged": {
-						"version": "10.2.11",
-						"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.2.11.tgz",
-						"integrity": "sha512-LRRrSogzbixYaZItE2APaS4l2eJMjjf5MbclRZpLJtcQJShcvUzKXsNeZgsLIZ0H0+fg2tL4B59fU9wHIHtFIA==",
-						"dev": true,
-						"requires": {
-								"chalk": "^4.0.0",
-								"cli-truncate": "2.1.0",
-								"commander": "^5.1.0",
-								"cosmiconfig": "^6.0.0",
-								"debug": "^4.1.1",
-								"dedent": "^0.7.0",
-								"enquirer": "^2.3.5",
-								"execa": "^4.0.1",
-								"listr2": "^2.1.0",
-								"log-symbols": "^4.0.0",
-								"micromatch": "^4.0.2",
-								"normalize-path": "^3.0.0",
-								"please-upgrade-node": "^3.2.0",
-								"string-argv": "0.3.1",
-								"stringify-object": "^3.3.0"
-						},
-						"dependencies": {
-								"ansi-styles": {
-										"version": "4.2.1",
-										"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-										"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-										"dev": true,
-										"requires": {
-												"@types/color-name": "^1.1.1",
-												"color-convert": "^2.0.1"
-										}
-								},
-								"braces": {
-										"version": "3.0.2",
-										"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-										"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-										"dev": true,
-										"requires": {
-												"fill-range": "^7.0.1"
-										}
-								},
-								"chalk": {
-										"version": "4.1.0",
-										"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-										"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-										"dev": true,
-										"requires": {
-												"ansi-styles": "^4.1.0",
-												"supports-color": "^7.1.0"
-										}
-								},
-								"color-convert": {
-										"version": "2.0.1",
-										"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-										"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-										"dev": true,
-										"requires": {
-												"color-name": "~1.1.4"
-										}
-								},
-								"color-name": {
-										"version": "1.1.4",
-										"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-										"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-										"dev": true
-								},
-								"commander": {
-										"version": "5.1.0",
-										"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-										"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-										"dev": true
-								},
-								"cross-spawn": {
-										"version": "7.0.3",
-										"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-										"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-										"dev": true,
-										"requires": {
-												"path-key": "^3.1.0",
-												"shebang-command": "^2.0.0",
-												"which": "^2.0.1"
-										}
-								},
-								"debug": {
-										"version": "4.1.1",
-										"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-										"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-										"dev": true,
-										"requires": {
-												"ms": "^2.1.1"
-										}
-								},
-								"execa": {
-										"version": "4.0.3",
-										"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-										"integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
-										"dev": true,
-										"requires": {
-												"cross-spawn": "^7.0.0",
-												"get-stream": "^5.0.0",
-												"human-signals": "^1.1.1",
-												"is-stream": "^2.0.0",
-												"merge-stream": "^2.0.0",
-												"npm-run-path": "^4.0.0",
-												"onetime": "^5.1.0",
-												"signal-exit": "^3.0.2",
-												"strip-final-newline": "^2.0.0"
-										}
-								},
-								"fill-range": {
-										"version": "7.0.1",
-										"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-										"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-										"dev": true,
-										"requires": {
-												"to-regex-range": "^5.0.1"
-										}
-								},
-								"get-stream": {
-										"version": "5.1.0",
-										"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-										"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-										"dev": true,
-										"requires": {
-												"pump": "^3.0.0"
-										}
-								},
-								"has-flag": {
-										"version": "4.0.0",
-										"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-										"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-										"dev": true
-								},
-								"is-number": {
-										"version": "7.0.0",
-										"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-										"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-										"dev": true
-								},
-								"is-stream": {
-										"version": "2.0.0",
-										"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-										"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-										"dev": true
-								},
-								"micromatch": {
-										"version": "4.0.2",
-										"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-										"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-										"dev": true,
-										"requires": {
-												"braces": "^3.0.1",
-												"picomatch": "^2.0.5"
-										}
-								},
-								"ms": {
-										"version": "2.1.2",
-										"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-										"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-										"dev": true
-								},
-								"npm-run-path": {
-										"version": "4.0.1",
-										"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-										"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-										"dev": true,
-										"requires": {
-												"path-key": "^3.0.0"
-										}
-								},
-								"path-key": {
-										"version": "3.1.1",
-										"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-										"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-										"dev": true
-								},
-								"shebang-command": {
-										"version": "2.0.0",
-										"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-										"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-										"dev": true,
-										"requires": {
-												"shebang-regex": "^3.0.0"
-										}
-								},
-								"shebang-regex": {
-										"version": "3.0.0",
-										"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-										"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-										"dev": true
-								},
-								"supports-color": {
-										"version": "7.1.0",
-										"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-										"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-										"dev": true,
-										"requires": {
-												"has-flag": "^4.0.0"
-										}
-								},
-								"to-regex-range": {
-										"version": "5.0.1",
-										"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-										"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-										"dev": true,
-										"requires": {
-												"is-number": "^7.0.0"
-										}
-								}
-						}
-				},
-				"listr2": {
-						"version": "2.2.0",
-						"resolved": "https://registry.npmjs.org/listr2/-/listr2-2.2.0.tgz",
-						"integrity": "sha512-Q8qbd7rgmEwDo1nSyHaWQeztfGsdL6rb4uh7BA+Q80AZiDET5rVntiU1+13mu2ZTDVaBVbvAD1Db11rnu3l9sg==",
-						"dev": true,
-						"requires": {
-								"chalk": "^4.0.0",
-								"cli-truncate": "^2.1.0",
-								"figures": "^3.2.0",
-								"indent-string": "^4.0.0",
-								"log-update": "^4.0.0",
-								"p-map": "^4.0.0",
-								"rxjs": "^6.5.5",
-								"through": "^2.3.8"
-						},
-						"dependencies": {
-								"ansi-styles": {
-										"version": "4.2.1",
-										"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-										"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-										"dev": true,
-										"requires": {
-												"@types/color-name": "^1.1.1",
-												"color-convert": "^2.0.1"
-										}
-								},
-								"chalk": {
-										"version": "4.1.0",
-										"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-										"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-										"dev": true,
-										"requires": {
-												"ansi-styles": "^4.1.0",
-												"supports-color": "^7.1.0"
-										}
-								},
-								"color-convert": {
-										"version": "2.0.1",
-										"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-										"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-										"dev": true,
-										"requires": {
-												"color-name": "~1.1.4"
-										}
-								},
-								"color-name": {
-										"version": "1.1.4",
-										"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-										"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-										"dev": true
-								},
-								"has-flag": {
-										"version": "4.0.0",
-										"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-										"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-										"dev": true
-								},
-								"indent-string": {
-										"version": "4.0.0",
-										"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-										"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-										"dev": true
-								},
-								"p-map": {
-										"version": "4.0.0",
-										"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-										"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-										"dev": true,
-										"requires": {
-												"aggregate-error": "^3.0.0"
-										}
-								},
-								"supports-color": {
-										"version": "7.1.0",
-										"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-										"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-										"dev": true,
-										"requires": {
-												"has-flag": "^4.0.0"
-										}
-								}
-						}
-				},
 				"livereload-js": {
 						"version": "2.4.0",
 						"resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.4.0.tgz",
@@ -10943,68 +10107,6 @@
 										"dev": true,
 										"requires": {
 												"has-flag": "^4.0.0"
-										}
-								}
-						}
-				},
-				"log-update": {
-						"version": "4.0.0",
-						"resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
-						"integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
-						"dev": true,
-						"requires": {
-								"ansi-escapes": "^4.3.0",
-								"cli-cursor": "^3.1.0",
-								"slice-ansi": "^4.0.0",
-								"wrap-ansi": "^6.2.0"
-						},
-						"dependencies": {
-								"ansi-styles": {
-										"version": "4.2.1",
-										"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-										"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-										"dev": true,
-										"requires": {
-												"@types/color-name": "^1.1.1",
-												"color-convert": "^2.0.1"
-										}
-								},
-								"astral-regex": {
-										"version": "2.0.0",
-										"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-										"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-										"dev": true
-								},
-								"color-convert": {
-										"version": "2.0.1",
-										"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-										"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-										"dev": true,
-										"requires": {
-												"color-name": "~1.1.4"
-										}
-								},
-								"color-name": {
-										"version": "1.1.4",
-										"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-										"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-										"dev": true
-								},
-								"is-fullwidth-code-point": {
-										"version": "3.0.0",
-										"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-										"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-										"dev": true
-								},
-								"slice-ansi": {
-										"version": "4.0.0",
-										"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-										"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-										"dev": true,
-										"requires": {
-												"ansi-styles": "^4.0.0",
-												"astral-regex": "^2.0.0",
-												"is-fullwidth-code-point": "^3.0.0"
 										}
 								}
 						}
@@ -11470,68 +10572,6 @@
 								"arrify": "^1.0.1",
 								"is-plain-obj": "^1.1.0",
 								"kind-of": "^6.0.3"
-						}
-				},
-				"minipass": {
-						"version": "3.1.3",
-						"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-						"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-						"dev": true,
-						"requires": {
-								"yallist": "^4.0.0"
-						},
-						"dependencies": {
-								"yallist": {
-										"version": "4.0.0",
-										"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-										"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-										"dev": true
-								}
-						}
-				},
-				"minipass-collect": {
-						"version": "1.0.2",
-						"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-						"integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-						"dev": true,
-						"requires": {
-								"minipass": "^3.0.0"
-						}
-				},
-				"minipass-flush": {
-						"version": "1.0.5",
-						"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-						"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-						"dev": true,
-						"requires": {
-								"minipass": "^3.0.0"
-						}
-				},
-				"minipass-pipeline": {
-						"version": "1.2.3",
-						"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.3.tgz",
-						"integrity": "sha512-cFOknTvng5vqnwOpDsZTWhNll6Jf8o2x+/diplafmxpuIymAjzoOolZG0VvQf3V2HgqzJNhnuKHYp2BqDgz8IQ==",
-						"dev": true,
-						"requires": {
-								"minipass": "^3.0.0"
-						}
-				},
-				"minizlib": {
-						"version": "2.1.0",
-						"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
-						"integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
-						"dev": true,
-						"requires": {
-								"minipass": "^3.0.0",
-								"yallist": "^4.0.0"
-						},
-						"dependencies": {
-								"yallist": {
-										"version": "4.0.0",
-										"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-										"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-										"dev": true
-								}
 						}
 				},
 				"mississippi": {
@@ -12471,12 +11511,6 @@
 								"mimic-fn": "^2.1.0"
 						}
 				},
-				"opencollective-postinstall": {
-						"version": "2.0.3",
-						"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
-						"integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
-						"dev": true
-				},
 				"opener": {
 						"version": "1.5.1",
 						"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
@@ -12783,15 +11817,6 @@
 						"dev": true,
 						"requires": {
 								"find-up": "^3.0.0"
-						}
-				},
-				"please-upgrade-node": {
-						"version": "3.2.0",
-						"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
-						"integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
-						"dev": true,
-						"requires": {
-								"semver-compare": "^1.0.0"
 						}
 				},
 				"plur": {
@@ -14163,16 +13188,6 @@
 						"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 						"dev": true
 				},
-				"restore-cursor": {
-						"version": "3.1.0",
-						"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-						"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-						"dev": true,
-						"requires": {
-								"onetime": "^5.1.0",
-								"signal-exit": "^3.0.2"
-						}
-				},
 				"ret": {
 						"version": "0.1.15",
 						"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -14240,15 +13255,6 @@
 						"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
 						"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
 						"dev": true
-				},
-				"rxjs": {
-						"version": "6.6.0",
-						"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.0.tgz",
-						"integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
-						"dev": true,
-						"requires": {
-								"tslib": "^1.9.0"
-						}
 				},
 				"safe-buffer": {
 						"version": "5.1.2",
@@ -14504,18 +13510,6 @@
 						"version": "5.7.1",
 						"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 						"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-						"dev": true
-				},
-				"semver-compare": {
-						"version": "1.0.0",
-						"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-						"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-						"dev": true
-				},
-				"semver-regex": {
-						"version": "2.0.0",
-						"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
-						"integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
 						"dev": true
 				},
 				"send": {
@@ -15086,12 +14080,6 @@
 						"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
 						"dev": true
 				},
-				"string-argv": {
-						"version": "0.3.1",
-						"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
-						"integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
-						"dev": true
-				},
 				"string-length": {
 						"version": "3.1.0",
 						"resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
@@ -15192,25 +14180,6 @@
 								"is-alphanumerical": "^1.0.0",
 								"is-decimal": "^1.0.2",
 								"is-hexadecimal": "^1.0.0"
-						}
-				},
-				"stringify-object": {
-						"version": "3.3.0",
-						"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
-						"integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
-						"dev": true,
-						"requires": {
-								"get-own-enumerable-property-symbols": "^3.0.0",
-								"is-obj": "^1.0.1",
-								"is-regexp": "^1.0.0"
-						},
-						"dependencies": {
-								"is-regexp": {
-										"version": "1.0.0",
-										"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-										"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-										"dev": true
-								}
 						}
 				},
 				"strip-ansi": {
@@ -15847,9 +14816,9 @@
 						}
 				},
 				"tar-stream": {
-						"version": "2.1.2",
-						"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
-						"integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+						"version": "2.1.3",
+						"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
+						"integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
 						"dev": true,
 						"requires": {
 								"bl": "^4.0.1",
@@ -17219,12 +16188,6 @@
 						"version": "2.0.0",
 						"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 						"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-						"dev": true
-				},
-				"which-pm-runs": {
-						"version": "1.0.0",
-						"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-						"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
 						"dev": true
 				},
 				"wide-align": {

--- a/src/CoreMenu.php
+++ b/src/CoreMenu.php
@@ -37,6 +37,7 @@ class CoreMenu {
 	public function init() {
 		add_action( 'admin_menu', array( $this, 'add_core_items' ) );
 		add_action( 'admin_menu', array( $this, 'add_core_setting_items' ) );
+		add_filter( 'add_menu_classes', array( $this, 'migrate_child_items' ) );
 	}
 
 	/**
@@ -157,5 +158,35 @@ class CoreMenu {
 			null,
 			false
 		);
+	}
+
+	/**
+	 * Migrate any remaining WooCommerce child items.
+	 *
+	 * @param array $menu Menu items.
+	 * @return array
+	 */
+	public function migrate_child_items( $menu ) {
+		global $submenu;
+
+		if ( ! isset( $submenu['woocommerce'] ) ) {
+			return;
+		}
+
+		foreach ( $submenu['woocommerce'] as $menu_item ) {
+			if ( 'woocommerce' === $menu_item[2] ) {
+				continue;
+			}
+
+			Menu::add_item(
+				'settings',
+				$menu_item[0],
+				$menu_item[1],
+				sanitize_title( $menu_item[0] ),
+				$menu_item[2]
+			);
+		}
+
+		return $menu;
 	}
 }

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -83,8 +83,8 @@ class Menu {
 	 * Init.
 	 */
 	public function init() {
-		add_action( 'admin_menu', array( $this, 'add_settings' ), 20 );
-		add_filter( 'add_menu_classes', array( $this, 'migrate_menu_items' ) );
+		add_filter( 'add_menu_classes', array( $this, 'add_settings' ), 20 );
+		add_filter( 'add_menu_classes', array( $this, 'migrate_menu_items' ), 30 );
 	}
 
 	/**
@@ -227,8 +227,11 @@ class Menu {
 
 	/**
 	 * Add the menu to the page output.
+	 *
+	 * @param array $menu Menu items.
+	 * @return array
 	 */
-	public function add_settings() {
+	public function add_settings( $menu ) {
 		global $submenu, $parent_file, $typenow, $self;
 
 		$categories = self::$categories;
@@ -255,5 +258,7 @@ class Menu {
 		);
 
 		$data_registry->add( 'wcNavigation', $categories );
+
+		return $menu;
 	}
 }


### PR DESCRIPTION
Fixes #9 

This PR migrates any remaining items under the original "WooCommerce" parent item to the new "Settings" menu.

Note that this also migrates some items like "Orders" and "Coupons" but will be fixed by https://github.com/woocommerce/navigation/issues/8.

### Screenshots
<img width="593" alt="Screen Shot 2020-07-07 at 10 32 52 AM" src="https://user-images.githubusercontent.com/10561050/86738152-81b6cb80-c03d-11ea-81c8-6aa7bb180140.png">
<img width="198" alt="Screen Shot 2020-07-07 at 10 32 18 AM" src="https://user-images.githubusercontent.com/10561050/86738169-854a5280-c03d-11ea-9bb7-7f59d3f53e96.png">

<img width="329" alt="ScreenCapture at Thu Jul 9 12:33:04 EDT 2020" src="https://user-images.githubusercontent.com/2098816/87066424-8d8ec300-c1e0-11ea-9c8e-6c585a5caabd.png">


### Testing

1. Open up the WP dashboard to a non-wc page.
1. Make sure the WooCommerce menu is shown but no submenu is shown.
1. Optionally, check the source code to make sure that no submenu items exist (note that we hide the submenu instead of unsetting to avoid breaking overriding this link as WCA does).
1. Open a WC registered screen, such as settings.  `wp-admin/admin.php?page=wc-settings`
1. Make sure items that previously remained under the WooCommerce menu item now exist in the navigation global under the children in "settings."  `window.wcSettings.wcNavigation[3].children`