### PR TITLE
Fix script dependencies

### DIFF
--- a/client/Navigation.js
+++ b/client/Navigation.js
@@ -32,7 +32,7 @@ export default class Navigation extends Component {
 
 	render() {
 		// @todo This should be updated to use a wp data store.
-		const items = window.wcSettings && window.wcSettings.wcNavigation ? window.wcSettings.wcNavigation : [];
+		const items = window.wcNavigation || [];
 
 		return (
 			<div className="woocommerce-navigation">

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -80,7 +80,7 @@ class Loader {
 		wp_register_script(
 			'woocommerce-navigation',
 			$script_url,
-			array_merge( $script_asset['dependencies'], array( WC_ADMIN_APP ) ),
+			$script_asset['dependencies'],
 			$script_asset['version'],
 			true
 		);

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -83,7 +83,7 @@ class Menu {
 	 * Init.
 	 */
 	public function init() {
-		add_filter( 'add_menu_classes', array( $this, 'add_settings' ), 20 );
+		add_filter( 'admin_enqueue_scripts', array( $this, 'enqueue_data' ), 20 );
 		add_filter( 'add_menu_classes', array( $this, 'migrate_menu_items' ), 30 );
 	}
 
@@ -231,7 +231,7 @@ class Menu {
 	 * @param array $menu Menu items.
 	 * @return array
 	 */
-	public function add_settings( $menu ) {
+	public function enqueue_data( $menu ) {
 		global $submenu, $parent_file, $typenow, $self;
 
 		$categories = self::$categories;
@@ -253,11 +253,7 @@ class Menu {
 			}
 		}
 
-		$data_registry = \Automattic\WooCommerce\Blocks\Package::container()->get(
-			\Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class
-		);
-
-		$data_registry->add( 'wcNavigation', $categories );
+		wp_add_inline_script( 'woocommerce-navigation', 'window.wcNavigation = ' . wp_json_encode( $categories ), 'before' );
 
 		return $menu;
 	}

--- a/tests/sample-test.php
+++ b/tests/sample-test.php
@@ -1,16 +1,20 @@
 <?php
+/**
+ * Sample test. To be removed once there is a real test.
+ *
+ * @package Woocommerce Navigation
+ */
 
 /**
  * Sample test
  *
  */
-
- class Sample_Test extends WC_REST_Unit_Test_Case {
+class Sample_Test extends WC_REST_Unit_Test_Case {
 	/**
 	 * Test that installation without permission is unauthorized.
 	 */
 	public function test_example() {
-        $number = 100;
+		$number = 100;
 		$this->assertEquals( 100, $number );
 	}
- }
+}


### PR DESCRIPTION
Using `wcSettings` to pass data to the client requires a dependency on Blocks or WC-Admin to be run first. This causes a delay in rendering the navigation, which looks bad.

This PR adds the data inline on its own so there is no dependency.

### Test

1. Load WC settings page `/wp-admin/admin.php?page=wc-settings`.
2. See the Nav appear faster than on `main`.