### PR TITLE
Add function to register post type

### DIFF
--- a/src/CoreMenu.php
+++ b/src/CoreMenu.php
@@ -8,6 +8,7 @@
 namespace Automattic\WooCommerce\Navigation;
 
 use Automattic\WooCommerce\Navigation\Menu;
+use Automattic\WooCommerce\Navigation\Screen;
 
 
 /**
@@ -65,20 +66,24 @@ class CoreMenu {
 	 */
 	public function add_core_items() {
 		// Orders category.
-		Menu::add_category(
-			__( 'Orders', 'woocommerce-navigation' ),
-			'edit_shop_orders',
-			'orders',
-			'edit.php?post_type=shop_order'
-		);
+		Screen::register_post_type( 'shop_order' );
 
 		// Products category.
+		Screen::register_post_type( 'product', 'shop_order' );
+
+		// Marketing category.
+		// @todo This should check if the marketing feature from WCA is active
+		// and allow that plugin to configure this menu item if so.
 		Menu::add_category(
-			__( 'Products', 'woocommerce-navigation' ),
-			'edit_products',
-			'products',
-			'edit.php?post_type=product'
+			__( 'Marketing', 'woocommerce-navigation' ),
+			'manage_woocommerce',
+			'marketing',
+			null,
+			null,
+			null,
+			false
 		);
+		Screen::register_post_type( 'shop_coupon', 'marketing' );
 
 		// Extensions category.
 		Menu::add_category(

--- a/src/CoreMenu.php
+++ b/src/CoreMenu.php
@@ -66,10 +66,12 @@ class CoreMenu {
 	 */
 	public function add_core_items() {
 		// Orders category.
-		Screen::register_post_type( 'shop_order' );
+		Screen::register_post_type( 'shop_order', null );
+		Menu::add_post_type_category( 'shop_order' );
 
 		// Products category.
-		Screen::register_post_type( 'product', 'shop_order' );
+		Screen::register_post_type( 'product', null );
+		Menu::add_post_type_category( 'product' );
 
 		// Marketing category.
 		// @todo This should check if the marketing feature from WCA is active

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -179,6 +179,40 @@ class Menu {
 	}
 
 	/**
+	 * Adds a post type as a menu category.
+	 *
+	 * @param string $post_type Post type.
+	 */
+	public static function add_post_type_category( $post_type ) {
+		$post_type_object = get_post_type_object( $post_type );
+
+		if ( ! $post_type_object ) {
+			return;
+		}
+
+		self::add_category(
+			esc_attr( $post_type_object->labels->menu_name ),
+			$post_type_object->cap->edit_posts,
+			$post_type,
+			"edit.php?post_type={$post_type}"
+		);
+		self::add_item(
+			$post_type,
+			esc_attr( $post_type_object->labels->all_items ),
+			$post_type_object->cap->edit_posts,
+			"{$post_type}-all-items",
+			"edit.php?post_type={$post_type}"
+		);
+		self::add_item(
+			$post_type,
+			esc_attr( $post_type_object->labels->add_new ),
+			$post_type_object->cap->create_posts,
+			"{$post_type}-add-new",
+			"post-new.php?post_type={$post_type}"
+		);
+	}
+
+	/**
 	 * Hides all WP admin menus items and adds screen IDs to check for new items.
 	 *
 	 * @param array $menu Menu items.

--- a/src/Screen.php
+++ b/src/Screen.php
@@ -113,4 +113,13 @@ class Screen {
 		}
 		self::$screen_ids[] = get_plugin_page_hookname( $callback, $parent );
 	}
+
+	/**
+	 * Register post type for use in WooCommerce Navigation screens.
+	 *
+	 * @param string $post_type Post type to add.
+	 */
+	public static function register_post_type( $post_type ) {
+		self::$post_types[] = $post_type;
+	}
 }

--- a/src/Screen.php
+++ b/src/Screen.php
@@ -134,15 +134,22 @@ class Screen {
 				$parent_slug,
 				esc_attr( $post_type_object->labels->menu_name ),
 				$post_type_object->cap->edit_posts,
-				"{$post_type}",
+				$post_type,
 				"edit.php?post_type=$post_type"
 			);
 		} else {
 			Menu::add_category(
 				esc_attr( $post_type_object->labels->menu_name ),
 				$post_type_object->cap->edit_posts,
-				"{$post_type}",
+				$post_type,
 				"edit.php?post_type=$post_type"
+			);
+			Menu::add_item(
+				"{$post_type}",
+				esc_attr( $post_type_object->labels->all_items ),
+				$post_type_object->cap->edit_posts,
+				"{$post_type}-all",
+				"edit.php?post_type={$post_type}"
 			);
 		}
 	}

--- a/src/Screen.php
+++ b/src/Screen.php
@@ -120,37 +120,21 @@ class Screen {
 	 * @param string $post_type Post type to add.
 	 * @param string $parent_slug Slug of parent menu item.
 	 */
-	public static function register_post_type( $post_type, $parent_slug = null ) {
+	public static function register_post_type( $post_type, $parent_slug ) {
 		self::$post_types[] = $post_type;
 
 		$post_type_object = get_post_type_object( $post_type );
 
-		if ( ! $post_type_object->show_in_menu ) {
+		if ( ! $post_type_object || ! $post_type_object->show_in_menu || ! $parent_slug ) {
 			return;
 		}
 
-		if ( $parent_slug ) {
-			Menu::add_item(
-				$parent_slug,
-				esc_attr( $post_type_object->labels->menu_name ),
-				$post_type_object->cap->edit_posts,
-				$post_type,
-				"edit.php?post_type=$post_type"
-			);
-		} else {
-			Menu::add_category(
-				esc_attr( $post_type_object->labels->menu_name ),
-				$post_type_object->cap->edit_posts,
-				$post_type,
-				"edit.php?post_type=$post_type"
-			);
-			Menu::add_item(
-				"{$post_type}",
-				esc_attr( $post_type_object->labels->all_items ),
-				$post_type_object->cap->edit_posts,
-				"{$post_type}-all",
-				"edit.php?post_type={$post_type}"
-			);
-		}
+		Menu::add_item(
+			$parent_slug,
+			esc_attr( $post_type_object->labels->menu_name ),
+			$post_type_object->cap->edit_posts,
+			$post_type,
+			"edit.php?post_type={$post_type}"
+		);
 	}
 }

--- a/src/Screen.php
+++ b/src/Screen.php
@@ -118,8 +118,32 @@ class Screen {
 	 * Register post type for use in WooCommerce Navigation screens.
 	 *
 	 * @param string $post_type Post type to add.
+	 * @param string $parent_slug Slug of parent menu item.
 	 */
-	public static function register_post_type( $post_type ) {
+	public static function register_post_type( $post_type, $parent_slug = null ) {
 		self::$post_types[] = $post_type;
+
+		$post_type_object = get_post_type_object( $post_type );
+
+		if ( ! $post_type_object->show_in_menu ) {
+			return;
+		}
+
+		if ( $parent_slug ) {
+			Menu::add_item(
+				$parent_slug,
+				esc_attr( $post_type_object->labels->menu_name ),
+				$post_type_object->cap->edit_posts,
+				"{$post_type}",
+				"edit.php?post_type=$post_type"
+			);
+		} else {
+			Menu::add_category(
+				esc_attr( $post_type_object->labels->menu_name ),
+				$post_type_object->cap->edit_posts,
+				"{$post_type}",
+				"edit.php?post_type=$post_type"
+			);
+		}
 	}
 }


### PR DESCRIPTION
Adds a method to register post types which will:

* Add to the menu.
* Migrate post types
* Ensure all post type screens show the wc nav.

### Testing

1. Visit various post type screens (orders, products, coupons). (e.g., `wp-admin/edit.php?post_type=shop_order`)
1. Make sure the new nav experience is used.
1. Make sure on non-wc pages that these items have been migrated.
1. Check that the items exist under `window.wcNavigation` in your console.