### PR TITLE
Update menu items to flat structure

### DIFF
--- a/client/Navigation.js
+++ b/client/Navigation.js
@@ -10,8 +10,26 @@ export default class Navigation extends Component {
 		adminMenu.classList.add( 'folded' );
 	}
 
+	getMenuItems() {
+		// @todo This should be updated to use a wp data store.
+		return window.wcNavigation || [];
+	}
+
+	getCategories() {
+		return this.getMenuItems().filter( ( item ) => ! item.parent );
+	}
+
+	getChildren( slug ) {
+		if ( ! slug ) {
+			return [];
+		}
+
+		return this.getMenuItems().filter( ( item ) => item.parent === slug );
+	}
+
 	renderMenuItem( item, depth = 0 ) {
 		const { slug, title, url } = item;
+		const children = this.getChildren( slug );
 
 		return (
 			<li
@@ -19,9 +37,9 @@ export default class Navigation extends Component {
 				className={ `woocommerce-navigation__menu-item woocommerce-navigation__menu-item-depth-${ depth }` }
 			>
 				<a href={ url }>{ title }</a>
-				{ item.children && item.children.length && (
+				{ children.length && (
 					<ul className="woocommerce-navigation__submenu">
-						{ item.children.map( ( childItem ) => {
+						{ children.map( ( childItem ) => {
 							return this.renderMenuItem( childItem, depth + 1 );
 						} ) }
 					</ul>
@@ -31,13 +49,10 @@ export default class Navigation extends Component {
 	}
 
 	render() {
-		// @todo This should be updated to use a wp data store.
-		const items = window.wcNavigation || [];
-
 		return (
 			<div className="woocommerce-navigation">
 				<ul className="woocommerce-navigation__menu">
-					{ items.map( ( item ) => {
+					{ this.getCategories().map( ( item ) => {
 						return this.renderMenuItem( item );
 					} ) }
 				</ul>

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -127,17 +127,15 @@ class Menu {
 	 * @param string $capability WordPress capability.
 	 * @param string $slug Menu slug.
 	 * @param string $url URL or menu callback.
-	 * @param string $icon Menu icon.
 	 * @param int    $order Menu order.
 	 * @param bool   $migrate Migrate the menu option and hide the old one.
 	 */
-	public static function add_category( $title, $capability, $slug, $url = null, $icon = null, $order = null, $migrate = true ) {
+	public static function add_category( $title, $capability, $slug, $url = null, $order = null, $migrate = true ) {
 		self::$menu_items[ $slug ] = array(
 			'title'      => $title,
 			'capability' => $capability,
 			'slug'       => $slug,
 			'url'        => self::get_callback_url( $url ),
-			'icon'       => $icon,
 			'order'      => $order,
 			'migrate'    => $migrate,
 		);
@@ -153,11 +151,10 @@ class Menu {
 	 * @param string $capability WordPress capability.
 	 * @param string $slug Menu slug.
 	 * @param string $url URL or menu callback.
-	 * @param string $icon Menu icon.
 	 * @param int    $order Menu order.
 	 * @param bool   $migrate Migrate the menu option and hide the old one.
 	 */
-	public static function add_item( $parent_slug, $title, $capability, $slug, $url = null, $icon = null, $order = null, $migrate = true ) {
+	public static function add_item( $parent_slug, $title, $capability, $slug, $url = null, $order = null, $migrate = true ) {
 		if ( isset( self::$menu_items[ $slug ] ) ) {
 			return;
 		}
@@ -168,7 +165,6 @@ class Menu {
 			'capability' => $capability,
 			'slug'       => $slug,
 			'url'        => self::get_callback_url( $url ),
-			'icon'       => $icon,
 			'order'      => $order,
 			'migrate'    => $migrate,
 		);

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -224,6 +224,15 @@ class Menu {
 	}
 
 	/**
+	 * Get registered menu items.
+	 *
+	 * @return array
+	 */
+	public static function get_items() {
+		return apply_filters( 'woocommerce_navigation_menu_items', self::$menu_items );
+	}
+
+	/**
 	 * Add the menu to the page output.
 	 *
 	 * @param array $menu Menu items.
@@ -232,7 +241,7 @@ class Menu {
 	public function enqueue_data( $menu ) {
 		global $submenu, $parent_file, $typenow, $self;
 
-		$menu_items = self::$menu_items;
+		$menu_items = self::get_items();
 		foreach ( $menu_items as $index => $menu_item ) {
 			if ( $menu_item[ 'capability' ] && ! current_user_can( $menu_item[ 'capability' ] ) ) {
 				unset( $menu_items[ $index ] );

--- a/tests/menu.php
+++ b/tests/menu.php
@@ -19,7 +19,7 @@ class WC_Tests_Navigation_Menu extends WC_REST_Unit_Test_Case {
 			'Test Category',
 			'manage_woocommerce',
 			'test-category',
-			'',
+			''
 		);
 
 		Menu::add_item(
@@ -27,7 +27,7 @@ class WC_Tests_Navigation_Menu extends WC_REST_Unit_Test_Case {
 			'Test Item',
 			'manage_woocommerce',
 			'test-item',
-			'',
+			''
 		);
 
 		$menu_items = Menu::instance()::get_items();
@@ -52,7 +52,7 @@ class WC_Tests_Navigation_Menu extends WC_REST_Unit_Test_Case {
 			'Test Item',
 			'manage_woocommerce',
 			'test-item',
-			'',
+			''
 		);
 
 		$this->assertEquals( 2, count( Menu::instance()::get_items() ) );
@@ -66,7 +66,7 @@ class WC_Tests_Navigation_Menu extends WC_REST_Unit_Test_Case {
 			__( 'Test Page', 'woocommerce-navigation' ),
 			'manage_woocommerce',
 			'test-plugins',
-			'wc-test',
+			'wc-test'
 		);
 
 		$url = Menu::instance()::get_items()['test-plugins']['url'];

--- a/tests/menu.php
+++ b/tests/menu.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Menu tests for registering categories and items.
+ *
+ * @package Woocommerce Navigation
+ */
+
+use Automattic\WooCommerce\Navigation\Menu;
+
+/**
+ * WC_Tests_Navigation_Menu
+ */
+class WC_Tests_Navigation_Menu extends WC_REST_Unit_Test_Case {
+	/**
+	 * Test that menu items can be added.
+	 */
+	public function test_add_menu_items() {
+		Menu::add_category(
+			'Test Category',
+			'manage_woocommerce',
+			'test-category',
+			'',
+		);
+
+		Menu::add_item(
+			'test-category',
+			'Test Item',
+			'manage_woocommerce',
+			'test-item',
+			'',
+		);
+
+		$menu_items = Menu::instance()::get_items();
+		$this->assertEquals( 2, count( $menu_items ) );
+		$this->assertCount( 7, $menu_items['test-item'] );
+		$this->assertArrayNotHasKey( 'parent', $menu_items['test-category'] );
+		$this->assertArrayHasKey( 'parent', $menu_items['test-item'] );
+		$this->assertArrayHasKey( 'title', $menu_items['test-item'] );
+		$this->assertArrayHasKey( 'capability', $menu_items['test-item'] );
+		$this->assertArrayHasKey( 'slug', $menu_items['test-item'] );
+		$this->assertArrayHasKey( 'url', $menu_items['test-item'] );
+		$this->assertArrayHasKey( 'order', $menu_items['test-item'] );
+		$this->assertArrayHasKey( 'migrate', $menu_items['test-item'] );
+	}
+
+	/**
+	 * Test adding a menu item that has already been added.
+	 */
+	public function test_duplicate_menu_slug() {
+		Menu::add_item(
+			'test-category',
+			'Test Item',
+			'manage_woocommerce',
+			'test-item',
+			'',
+		);
+
+		$this->assertEquals( 2, count( Menu::instance()::get_items() ) );
+	}
+
+	/**
+	 * Test that the callback is converted to a URL.
+	 */
+	public function test_callback_url() {
+		Menu::add_category(
+			__( 'Test Page', 'woocommerce-navigation' ),
+			'manage_woocommerce',
+			'test-plugins',
+			'wc-test',
+		);
+
+		$url = Menu::instance()::get_items()['test-plugins']['url'];
+		$this->assertEquals( 'admin.php?page=wc-test', $url );
+	}
+}


### PR DESCRIPTION
Fixes #34 

* Changes data to flat from tree structure.
* Removes the `icon` property.
* Adds some initial tests around the menu.

### Testing

1. Make sure menu items still show as expected on the front-end.
1. Make sure tests pass.