### PR TITLE
Add tests for Screen class

### DIFF
--- a/src/Menu.php
+++ b/src/Menu.php
@@ -111,6 +111,10 @@ class Menu {
 	public static function get_parent_key( $callback ) {
 		global $submenu;
 
+		if ( ! $submenu ) {
+			return null;
+		}
+
 		// This is already a parent item.
 		if ( isset( $submenu[ $callback ] ) ) {
 			return null;

--- a/src/Screen.php
+++ b/src/Screen.php
@@ -52,12 +52,26 @@ class Screen {
 	}
 
 	/**
+	 * Returns an array of filtered screen ids.
+	 */
+	public static function get_screen_ids() {
+		return apply_filters( 'woocommerce_navigation_screen_ids', self::$screen_ids );
+	}
+
+	/**
+	 * Returns an array of registered post types.
+	 */
+	public static function get_post_types() {
+		return apply_filters( 'woocommerce_navigation_post_types', self::$post_types );
+	}
+
+	/**
 	 * Check if we're on a WooCommerce page
 	 *
 	 * @return bool
 	 */
 	public static function is_woocommerce_page() {
-		global $pagenow, $plugin_page;
+		global $pagenow;
 
 		// Get post type if on a post screen.
 		$post_type = '';
@@ -68,15 +82,16 @@ class Screen {
 				$post_type = sanitize_text_field( wp_unslash( $_GET['post_type'] ) ); // phpcs:ignore CSRF ok.
 			}
 		}
-		$post_types = apply_filters( 'woocommerce_navigation_post_types', self::$post_types );
+		$post_types = self::get_post_types();
 
 		// Get current screen ID.
-		$current_screen = get_current_screen();
-		$screen_ids     = apply_filters( 'woocommerce_navigation_screen_ids', self::$screen_ids );
+		$current_screen    = get_current_screen();
+		$screen_ids        = self::get_screen_ids();
+		$current_screen_id = $current_screen ? $current_screen->id : null;
 
 		if (
 			in_array( $post_type, $post_types, true ) ||
-			in_array( $current_screen->id, self::$screen_ids, true )
+			in_array( $current_screen_id, $screen_ids, true )
 		) {
 			return true;
 		}
@@ -111,6 +126,14 @@ class Screen {
 		if ( ! $parent ) {
 			$parent = Menu::get_parent_key( $callback );
 		}
+
+		$screen_id = get_plugin_page_hookname( $callback, $parent );
+
+		// This screen has already been added.
+		if ( in_array( $screen_id, self::$screen_ids, true ) ) {
+			return;
+		}
+
 		self::$screen_ids[] = get_plugin_page_hookname( $callback, $parent );
 	}
 

--- a/tests/screen.php
+++ b/tests/screen.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Screen tests for adding registered screen IDs for the navigation.
+ *
+ * @package Woocommerce Navigation
+ */
+
+use Automattic\WooCommerce\Navigation\Menu;
+use Automattic\WooCommerce\Navigation\Screen;
+
+/**
+ * WC_Tests_Navigation_Screen
+ */
+class WC_Tests_Navigation_Screen extends WC_REST_Unit_Test_Case {
+	/**
+	 * Test that screens can be added.
+	 */
+	public function test_add_screen() {
+		Screen::add_screen( 'wc-test' );
+		Screen::add_screen( 'wc-page' );
+
+		$screen_ids = Screen::instance()::get_screen_ids();
+		$this->assertEquals( 2, count( $screen_ids ) );
+		$this->assertEquals( 'admin_page_wc-test', $screen_ids[0] );
+		$this->assertEquals( 'admin_page_wc-page', $screen_ids[1] );
+	}
+
+	/**
+	 * Test that adding an already registered page does not get added again.
+	 */
+	public function test_add_duplicate_screen() {
+		Screen::add_screen( 'wc-page' );
+		$screen_ids = Screen::instance()::get_screen_ids();
+		$this->assertEquals( 2, count( $screen_ids ) );
+	}
+
+	/**
+	 * Test that post types can be registered.
+	 */
+	public function test_register_post_types() {
+		Screen::register_post_type( 'custom-post-type', 'test-category' );
+		$this->assertContains( 'custom-post-type', Screen::get_post_types() );
+		// @todo Uncomment this line after https://github.com/woocommerce/navigation/pull/35 is merged.
+		// $this->assertArrayHasKey( 'custom-post-type', Menu::instance()::get_items() );
+	}
+
+	/**
+	 * Test the check for detecting if we're on a WooCommerce page.
+	 */
+	public function test_is_woocommerce_page() {
+		Screen::add_screen( 'wc-page' );
+		Screen::register_post_type( 'custom-post-type', 'test-category' );
+
+		// Mimic the global variables to detect pages.
+		// phpcs:disable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+		global $pagenow, $current_screen;
+		$_pagenow        = $pagenow;
+		$_current_screen = $current_screen;
+		$_post_type      = isset( $_GET['post_type'] ) ? sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) : null; // phpcs:ignore csrf ok.
+		$_post_id        = isset( $_GET['post'] ) ? sanitize_text_field( wp_unslash( $_GET['post'] ) ) : null; // phpcs:ignore csrf ok.
+
+		// Create test posts.
+		$post_id             = wp_insert_post(
+			array(
+				'post_title' => 'Test post',
+				'post_type'  => 'post',
+			)
+		);
+		$custom_post_type_id = wp_insert_post(
+			array(
+				'post_title' => 'Test post',
+				'post_type'  => 'custom-post-type',
+			)
+		);
+
+		// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
+		// Registered post types.
+		$pagenow           = 'edit.php';
+		$_GET['post_type'] = null;
+		$this->assertEquals( false, Screen::is_woocommerce_page() );
+		$pagenow      = 'post.php';
+		$_GET['post'] = $post_id;
+		$this->assertEquals( false, Screen::is_woocommerce_page() );
+		$pagenow           = 'edit.php';
+		$_GET['post_type'] = 'custom-post-type';
+		$_GET['post']      = null;
+		$this->assertEquals( true, Screen::is_woocommerce_page() );
+		$pagenow      = 'post.php';
+		$_GET['post'] = $custom_post_type_id;
+		$this->assertEquals( true, Screen::is_woocommerce_page() );
+
+		// Reset globals to original values.
+		$pagenow           = $_pagenow;
+		$_GET['post_type'] = $_post_type;
+		$_GET['post_id']   = $_post_id;
+
+		// Registered pages.
+		$current_screen = (object) array(
+			'id'       => 'admin_page_non-wc-page',
+			'in_admin' => true,
+		);
+		$this->assertEquals( false, Screen::is_woocommerce_page() );
+		$current_screen = (object) array(
+			'id'       => 'admin_page_wc-page',
+			'in_admin' => true,
+		);
+		$this->assertEquals( true, Screen::is_woocommerce_page() );
+
+		// Reset globals to original values.
+		$current_screen = $_current_screen;
+		// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
+}


### PR DESCRIPTION
* Adds tests for `Screen`.
* Adds getters and filters to screen posts and screen ids.

**Note**: The tests do some modification of globals prior to reverting to original values.  We could add filters for each of these instead of overriding, but I think the tests here may be a good use case for overriding to get us as close to simulating actual WP logic as possible.

### Testing
1. Make sure no regressions have been made on the frontend.
1. Make sure all tests pass.