### PR TITLE
Remove user profile link

### DIFF
--- a/src/CoreMenu.php
+++ b/src/CoreMenu.php
@@ -170,19 +170,6 @@ class CoreMenu {
 				'menuId'     => 'secondary',
 			)
 		);
-
-		// User profile.
-		// @todo This may fall under a tertiary menu.
-		Menu::add_category(
-			array(
-				'title'      => wp_get_current_user()->user_login,
-				'capability' => 'read',
-				'id'         => 'profile',
-				'url'        => 'profile.php',
-				'migrate'    => false,
-				'menuId'     => 'secondary',
-			)
-		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #69

Removes the user profile link from the menu.

This was originally intended to be a user profile link, but for the time being this will not be implemented to match core designs.

## Testing
1. Check that no user profile link exists.
1. Make sure nothing else is broken.